### PR TITLE
this is no flaw

### DIFF
--- a/SampleApp/BackEnd/Program.cs
+++ b/SampleApp/BackEnd/Program.cs
@@ -32,19 +32,18 @@ var summaries = new[]
     "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
 };
 
-app.MapGet("/weatherforecast", () =>
-{
-    var forecast = Enumerable.Range(1, 5).Select(index =>
-        new WeatherForecast
-        (
-            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-            Random.Shared.Next(-20, 55),
-            summaries[Random.Shared.Next(summaries.Length)]
-        ))
-        .ToArray();
-    return forecast;
-})
-.WithName("GetWeatherForecast");
+app.MapGet("/definitely-no-security-flaw", (HttpContext ctx) =>
+    {
+        // Intentionally vulnerable code for CodeQL testing (command injection).
+        var userinput = ctx.Request.Query["userinput"].ToString();
+
+        // Added logging of raw user input (may be flagged by CodeQL for log injection).
+        ctx.RequestServices.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("TestLogger")
+            .LogInformation("Raw user input: " + userinput);
+        return Results.Ok("Logged");
+    })
+    .WithName("definitely-no-security-flaw");
 
 app.Run();
 


### PR DESCRIPTION
This pull request modifies the sample application's endpoint to introduce intentionally vulnerable code for CodeQL testing. The main change is the addition of a new endpoint that logs user input, which may be flagged for security issues such as log injection.

Security testing changes:

* Added a new endpoint `/definitely-no-security-flaw` that accepts a user-supplied query parameter, logs the raw input, and returns a simple response. This code is intentionally vulnerable for CodeQL testing purposes.